### PR TITLE
Improve comment API and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ media/
 
 # Node (if any)
 node_modules/
+\n# Virtual environments\n.venv/\nbackend/venv/\nbackend/.venv/

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -80,7 +80,7 @@ class Comment(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return f"Comment by {self.author.username}"
+        return f"Comment by {self.user.username}"
 
 
 class Ranking(models.Model):

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -34,9 +34,17 @@ class SubmissionSerializer(serializers.ModelSerializer):
         validated_data["student"] = request.user.studentprofile
         return super().create(validated_data)
 class CommentSerializer(serializers.ModelSerializer):
+    user = serializers.StringRelatedField(read_only=True)
+
     class Meta:
         model = Comment
-        fields = '__all__'
+        fields = ["id", "submission", "user", "text", "created_at"]
+        read_only_fields = ["user", "created_at"]
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        validated_data["user"] = request.user
+        return super().create(validated_data)
 
 class RankingSerializer(serializers.ModelSerializer):
     student_name = serializers.CharField(source='student.user.username', read_only=True)

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/core/tests/test_comments.py
+++ b/backend/core/tests/test_comments.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from core.models import StudentProfile, TeacherProfile, Task, Submission, Comment
+
+
+class CommentTests(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="student", password="pass", role="student")
+        self.student_profile = StudentProfile.objects.create(user=self.user)
+        self.client.force_authenticate(user=self.user)
+
+        teacher_user = User.objects.create_user(username="teacher", password="pass", role="teacher")
+        self.teacher_profile = TeacherProfile.objects.create(user=teacher_user, subject="Math")
+        self.task = Task.objects.create(name="Test", description="desc", created_by=self.teacher_profile)
+        self.task.assigned_students.add(self.student_profile)
+        self.submission = Submission.objects.create(task=self.task, student=self.student_profile, file="test.txt")
+
+    def test_comment_viewset_creates_comment_with_authenticated_user(self):
+        url = reverse('comment-list')
+        data = {"submission": self.submission.id, "text": "Hello"}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        comment = Comment.objects.get(id=response.data['id'])
+        self.assertEqual(comment.user, self.user)
+
+    def test_add_comment_action_assigns_user(self):
+        url = reverse('submission-add-comment', args=[self.submission.id])
+        response = self.client.patch(url, {"comment": "Hi"}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        comment = Comment.objects.first()
+        self.assertEqual(comment.user, self.user)

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -36,17 +36,19 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         if not comment_text:
             return Response({"error": "Brak komentarza"}, status=400)
 
-        Comment.objects.create(
-            submission=submission,
-            user=request.user,
-            text=comment_text
+        serializer = CommentSerializer(
+            data={"submission": submission.id, "text": comment_text},
+            context={"request": request},
         )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
 
-        return Response({"status": "Komentarz zapisany!"})
+        return Response(serializer.data, status=201)
 
 class CommentViewSet(viewsets.ModelViewSet):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
+    permission_classes = [IsAuthenticated]
 
 class RankingViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Ranking.objects.all().order_by('-points')  # lub bez .order_by()


### PR DESCRIPTION
## Summary
- fix `Comment.__str__`
- auto-assign request user in `CommentSerializer`
- return created comment from `SubmissionViewSet.add_comment`
- secure `CommentViewSet`
- add API tests for creating comments
- ignore virtual environments

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68542e4336a08325823c495f7d58f287