### PR TITLE
Add task and comment API enhancements

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -36,7 +36,7 @@ schema_view = get_schema_view(
     public=True,
     permission_classes=[AllowAny],
 )
-from core.views import my_tasks, SubmissionUploadView
+from core.views import my_tasks, SubmissionUploadView, TopRankingView
 
 router = routers.DefaultRouter()
 router.register(r"users", core_views.UserViewSet)
@@ -65,5 +65,13 @@ urlpatterns = [
     path("api/my-student-profile/", core_views.MyStudentProfileView.as_view()),
     path("api/my-tasks/", my_tasks),
     path("api/submit-task/", SubmissionUploadView.as_view(), name="submit-task"),
-    path("api/submissions/<int:pk>/add_comment/", core_views.SubmissionViewSet.as_view({'patch': 'add_comment'})),
+    path(
+        "api/submissions/<int:pk>/add_comment/",
+        core_views.SubmissionViewSet.as_view({"patch": "add_comment", "post": "add_comment"}),
+    ),
+    path(
+        "api/submissions/<int:pk>/comments/",
+        core_views.SubmissionViewSet.as_view({"get": "comments"}),
+    ),
+    path("api/top-ranking/", TopRankingView.as_view()),
 ]

--- a/backend/core/migrations/0001_initial.py
+++ b/backend/core/migrations/0001_initial.py
@@ -250,9 +250,16 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("text", models.TextField()),
+                (
+                    "role",
+                    models.CharField(
+                        choices=[("student", "Student"), ("teacher", "Teacher")],
+                        max_length=20,
+                    ),
+                ),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 (
-                    "user",
+                    "author",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
                         to=settings.AUTH_USER_MODEL,

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -75,12 +75,13 @@ class Submission(models.Model):
 
 class Comment(models.Model):
     submission = models.ForeignKey(Submission, on_delete=models.CASCADE, related_name="comments")
-    user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
+    author = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
     text = models.TextField()
+    role = models.CharField(max_length=20, choices=[("student", "Student"), ("teacher", "Teacher")])
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return f"Comment by {self.user.username}"
+        return f"Comment by {self.author.username}"
 
 
 class Ranking(models.Model):

--- a/backend/core/tests/test_comments.py
+++ b/backend/core/tests/test_comments.py
@@ -1,3 +1,8 @@
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+import django
+django.setup()
+
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
@@ -17,6 +22,11 @@ class CommentTests(APITestCase):
         self.task = Task.objects.create(name="Test", description="desc", created_by=self.teacher_profile)
         self.task.assigned_students.add(self.student_profile)
         self.submission = Submission.objects.create(task=self.task, student=self.student_profile, file="test.txt")
+        self.task2 = Task.objects.create(name="Test2", description="desc2", created_by=self.teacher_profile)
+        self.task2.assigned_students.add(self.student_profile)
+
+        # second submission for ranking test
+        self.submission2 = Submission.objects.create(task=self.task2, student=self.student_profile, file="file2.txt")
 
     def test_comment_viewset_creates_comment_with_authenticated_user(self):
         url = reverse('comment-list')
@@ -24,11 +34,38 @@ class CommentTests(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         comment = Comment.objects.get(id=response.data['id'])
-        self.assertEqual(comment.user, self.user)
+        self.assertEqual(comment.author, self.user)
+        self.assertEqual(comment.role, "student")
 
-    def test_add_comment_action_assigns_user(self):
+    def test_add_comment_action_assigns_author_and_role(self):
         url = reverse('submission-add-comment', args=[self.submission.id])
-        response = self.client.patch(url, {"comment": "Hi"}, format='json')
+        response = self.client.patch(url, {"text": "Hi"}, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         comment = Comment.objects.first()
-        self.assertEqual(comment.user, self.user)
+        self.assertEqual(comment.author, self.user)
+        self.assertEqual(comment.role, "student")
+
+    def test_submission_comments_endpoint_returns_comments(self):
+        Comment.objects.create(submission=self.submission, author=self.user, text="a", role="student")
+        Comment.objects.create(submission=self.submission, author=self.user, text="b", role="student")
+        url = reverse('submission-comments', args=[self.submission.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['text'], "a")
+
+    def test_top_ranking_endpoint(self):
+        url = "/api/top-ranking/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]['username'], self.user.username)
+        self.assertEqual(response.data[0]['completed'], 2)
+
+    def test_my_tasks_endpoint_returns_sorted_tasks(self):
+        url = "/api/my-tasks/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]["id"], self.task2.id)
+        first_task = response.data[0]
+        self.assertTrue(first_task["status"])  # has submission
+        self.assertIsNotNone(first_task["submission_id"])


### PR DESCRIPTION
## Summary
- implement extended Comment model with role tracking
- expand TaskSerializer to expose submission info
- add top ranking and comments endpoints
- secure submission comment actions and list
- provide comprehensive tests for new endpoints

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6855082b96e88325bdda842e80696051