### PR TITLE
Add current user endpoint and role-based login

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path("api/my-student-profile/", core_views.MyStudentProfileView.as_view()),
+    path("api/me/", core_views.CurrentUserView.as_view()),
     path("api/my-tasks/", my_tasks),
     path("api/submit-task/", SubmissionUploadView.as_view(), name="submit-task"),
     path(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -131,6 +131,21 @@ class MyStudentProfileView(APIView):
         return Response(StudentProfileSerializer(profile).data)
 
 
+class CurrentUserView(APIView):
+    """Return basic info about the authenticated user."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+        data = {
+            "id": user.id,
+            "username": user.username,
+            "role": getattr(user, "role", None),
+        }
+        return Response(data)
+
+
 class TopRankingView(APIView):
     permission_classes = [IsAuthenticated]
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,11 @@
+export async function fetchCurrentUser(token: string) {
+    const res = await fetch("http://localhost:8000/api/me/", {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    if (!res.ok) {
+        throw new Error("Failed to fetch user info");
+    }
+    return res.json();
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,6 +1,7 @@
 // src/pages/login.tsx
 import { useState } from "react"
 import { useRouter } from "next/router"
+import { fetchCurrentUser } from "@/lib/api"
 
 export default function LoginPage() {
     const [username, setUsername] = useState("")
@@ -22,7 +23,21 @@ export default function LoginPage() {
             if (res.ok) {
                 localStorage.setItem("access_token", data.access)
                 localStorage.setItem("refresh_token", data.refresh)
-                router.push("/student")
+
+                try {
+                    const user = await fetchCurrentUser(data.access)
+                    localStorage.setItem("user_role", user.role)
+                    if (user.role === "student") {
+                        router.push("/student")
+                    } else if (user.role === "teacher") {
+                        router.push("/teacher")
+                    } else {
+                        router.push("/")
+                    }
+                } catch (e) {
+                    console.error(e)
+                    router.push("/")
+                }
             } else {
                 setError(data.detail || "Błędne dane logowania")
             }


### PR DESCRIPTION
## Summary
- add `CurrentUserView` API endpoint in Django
- expose `/api/me/` URL path
- create frontend helper to fetch current user data
- update login flow to store user role and redirect accordingly

## Testing
- `python manage.py test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685527af181c83259e49b8cecfae806f