### PR TITLE
Use env var for API URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,8 +1,14 @@
 import type { NextConfig } from "next";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.8",
+        "dotenv": "^16.5.0",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2501,6 +2502,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.6.8",
+    "dotenv": "^16.5.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.23.0",
-    "axios": "^1.6.8"
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
 interface Task {
     id: number;
     name: string;
@@ -40,7 +42,7 @@ const TaskCard = ({
         setLoadingComments(true);
         try {
             const res = await fetch(
-                `http://localhost:8000/api/submissions/${task.id}/comments/`,
+                `${API_URL}/api/submissions/${task.id}/comments/`,
                 {
                     headers: {
                         Authorization: `Bearer ${token}`,
@@ -72,7 +74,7 @@ const TaskCard = ({
         if (!comment) return;
 
         try {
-            const res = await fetch(`http://localhost:8000/api/submissions/${task.id}/add_comment/`, {
+            const res = await fetch(`${API_URL}/api/submissions/${task.id}/add_comment/`, {
                 method: "PATCH",
                 headers: {
                     Authorization: `Bearer ${token}`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,7 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
 export async function fetchCurrentUser(token: string) {
-    const res = await fetch("http://localhost:8000/api/me/", {
+    const res = await fetch(`${API_URL}/api/me/`, {
         headers: {
             Authorization: `Bearer ${token}`,
         },

--- a/frontend/src/pages/student.tsx
+++ b/frontend/src/pages/student.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import TaskCard from "@/components/TaskCard"; // zakładam, że TaskCard znajduje się w src/components
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
 interface Task {
     id: number;
     name: string;
@@ -33,7 +35,7 @@ export default function StudentDashboard() {
             if (!token) return;
 
             try {
-                const res = await fetch("http://localhost:8000/api/my-tasks/", {
+                const res = await fetch(`${API_URL}/api/my-tasks/`, {
                     headers: {
                         Authorization: `Bearer ${token}`,
                         "Content-Type": "application/json",
@@ -55,7 +57,7 @@ export default function StudentDashboard() {
             if (!token) return;
 
             try {
-                const res = await fetch("http://localhost:8000/api/top-ranking/", {
+                const res = await fetch(`${API_URL}/api/top-ranking/`, {
                     headers: { Authorization: `Bearer ${token}` },
                 });
                 if (res.ok) {
@@ -89,7 +91,7 @@ export default function StudentDashboard() {
         formData.append("task", taskId.toString());
 
         try {
-            const res = await fetch("http://localhost:8000/api/submit-task/", {
+            const res = await fetch(`${API_URL}/api/submit-task/`, {
                 method: "POST",
                 headers: {
                     Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- create `.env.example`
- read `NEXT_PUBLIC_API_URL` in `next.config.ts`
- reference `NEXT_PUBLIC_API_URL` in all fetch calls
- add dotenv and unignore `.env.example`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68552d9c9c9483259401882fc130f4d3