### PR TITLE
Remove duplicate JWT routes

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -67,8 +67,6 @@ urlpatterns = [
         schema_view.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path("api/my-student-profile/", core_views.MyStudentProfileView.as_view()),
     path("api/me/", core_views.CurrentUserView.as_view()),
     path("api/my-tasks/", my_tasks),


### PR DESCRIPTION
## Summary
- remove repeated JWT endpoints in `backend/config/urls.py`

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68552da09ffc8325b27ddb46d2bc3211